### PR TITLE
A couple little fixes before gallery listing

### DIFF
--- a/_gallery_info.yml
+++ b/_gallery_info.yml
@@ -13,3 +13,5 @@ tags:
     - hvplot
     - s3fs
     - scipy
+  events:
+    - Cook-off 2025

--- a/notebooks/ch2-mar-2023-tornado_jdh.ipynb
+++ b/notebooks/ch2-mar-2023-tornado_jdh.ipynb
@@ -11,25 +11,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```{image} ../thumbnails/thumbnail.png\n",
-    ":alt: Project Pythia logo\n",
-    ":width: 200px\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Next, title your notebook appropriately with a top-level Markdown header, `#` (see the very first cell above). Do not use this level header anywhere else in the notebook. Our book build process will use this title in the navbar, table of contents, etc. Keep it short, keep it descriptive. \n",
-    "\n",
-    "Follow this with a `---` cell to visually distinguish the transition to the prerequisites section."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "---"
    ]
   },
@@ -38,7 +19,8 @@
    "metadata": {},
    "source": [
     "# Overview\n",
-    "The tornado outbreak of March 24–27, 2023 was a devastating multi-day severe weather event that swept across the Southern United States, particularly impacting Mississippi, Alabama, Tennessee, and Georgia. Triggered by a slow-moving upper-level trough interacting with moist, unstable air from the Gulf of Mexico, the outbreak produced 35 confirmed tornadoes, including a violent EF4 that tore through Rolling Fork, Midnight, and Silver City, Mississippi with peak winds of 195 mph. This EF4 tornado alone caused catastrophic damage and multiple fatalities and brought tornado emergencies ahead of widespread destruction.<br>\n",
+    "The tornado outbreak of March 24–27, 2023 was a devastating multi-day severe weather event that swept across the Southern United States, particularly impacting Mississippi, Alabama, Tennessee, and Georgia. Triggered by a slow-moving upper-level trough interacting with moist, unstable air from the Gulf of Mexico, the outbreak produced 35 confirmed tornadoes, including a violent EF4 that tore through Rolling Fork, Midnight, and Silver City, Mississippi with peak winds of 195 mph. This EF4 tornado alone caused catastrophic damage and multiple fatalities and brought tornado emergencies ahead of widespread destruction.\n",
+    "\n",
     "Over the four-day span, the system also unleashed damaging straight-line winds, large hail, and flooding. In total, the outbreak resulted in 23 fatalities (plus two from non-tornadic causes), over 230 injuries, and an estimated $1.9 billion in damage. The event was notable not only for its intensity but also for its geographic breadth and the prolonged nature of the severe weather threat.\n",
     "\n",
     "---\n",


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
As part of my review of https://github.com/ProjectPythia/cookbook-gallery/pull/37 (listing this cookbook on the Pythia gallery), I found just two little things to clean up.

In this PR:
- get rid of some extraneous template text in one notebook
- add the "Cook-off 2025" event tag to `_gallery_info.yml` (since this cookbook originated at the 2025 event!)